### PR TITLE
Add use of dataProviders in test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,4 +77,4 @@ All notable changes to `google-places` will be documented in this file
 
 
 ## 1.2.1 - 2021-07-20
-- add use of dataProviders for providing arrays of test params for city & zip tests
+- add use of `@dataProvider` for providing arrays of test params for city & zip tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,3 +74,7 @@ All notable changes to `google-places` will be documented in this file
 - refactor `ExtractTest` & `AutocompleteTest` from `Feature` to `Unit` namespace
 - add encrypting of google places API variables in local & travis ci environments
 - make `ConfigTest` for testing config values
+
+
+## 1.2.1 - 2021-07-20
+- add use of dataProviders for providing arrays of test params for city & zip tests

--- a/tests/Feature/RouteTest.php
+++ b/tests/Feature/RouteTest.php
@@ -6,17 +6,26 @@ use Sfneal\GooglePlaces\Tests\TestCase;
 
 class RouteTest extends TestCase
 {
-    /** @test */
-    public function city_route_can_be_accessed()
+    /**
+     * @test
+     * @dataProvider cityProvider
+     * @param string $query
+     * @param int $expectedResults
+     */
+    public function city_route_can_be_accessed(string $query, int $expectedResults)
     {
-        $this->responseAssertions(route('places.city', ['q' => 'franklin']), 5);
-        $this->responseAssertions(route('places.city', ['q' => 'boston']), 5);
-        $this->responseAssertions(route('places.city', ['q' => '02038']), 1);
+        $this->responseAssertions(route('places.city', ['q' => $query]), $expectedResults);
     }
 
-    /** @test */
-    public function zip_route_can_be_accessed()
+    /**
+     * @test
+     * @dataProvider zipProvider
+     * @param string $query
+     * @param int $expectedResults
+     * @param array $contentKeys
+     */
+    public function zip_route_can_be_accessed(string $query, int $expectedResults, array $contentKeys)
     {
-        $this->responseAssertions(route('places.zip', ['q' => '02038']), 1, ['id', 'text']);
+        $this->responseAssertions(route('places.zip', ['q' => $query]), $expectedResults, $contentKeys);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,6 +41,35 @@ abstract class TestCase extends OrchestraTestCase
     }
 
     /**
+     * Retrieve an array of 'city' query strings for autocomplete tests.
+     *
+     * @return array
+     */
+    public function cityProvider(): array
+    {
+        return [
+            ['franklin', 5],
+            ['02038', 1],
+            ['boston', 5],
+            ['new york', 5],
+        ];
+    }
+
+    /**
+     * Retrieve an array of 'zip' query strings for autocomplete tests.
+     *
+     * @return array
+     */
+    public function zipProvider(): array
+    {
+        return [
+            ['0203', 4, ['id', 'text']],
+            ['02038', 1, ['id', 'text']],
+            ['10001', 1, ['id', 'text']],
+        ];
+    }
+
+    /**
      * Execute response assertions for route test methods.
      *
      * @param string $uri

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Sfneal\GooglePlaces\Providers\GooglePlacesServiceProvider;
 
-class TestCase extends OrchestraTestCase
+abstract class TestCase extends OrchestraTestCase
 {
     /**
      * Define environment setup.

--- a/tests/Unit/AutocompleteTest.php
+++ b/tests/Unit/AutocompleteTest.php
@@ -7,18 +7,26 @@ use Sfneal\GooglePlaces\Tests\TestCase;
 
 class AutocompleteTest extends TestCase
 {
-    /** @test */
-    public function city()
+    /**
+     * @test
+     * @dataProvider cityProvider
+     * @param string $query
+     * @param int $expectedResults
+     */
+    public function city(string $query, int $expectedResults)
     {
-        $this->contentAssertions(Autocomplete::city('franklin'), 5);
-        $this->contentAssertions(Autocomplete::city('02038'), 1);
-        $this->contentAssertions(Autocomplete::city('boston'), 5);
+        $this->contentAssertions(Autocomplete::city($query), $expectedResults);
     }
 
-    /** @test */
-    public function zip()
+    /**
+     * @test
+     * @dataProvider zipProvider
+     * @param string $query
+     * @param int $expectedResults
+     * @param array $contentKeys
+     */
+    public function zip(string $query, int $expectedResults, array $contentKeys)
     {
-        $this->contentAssertions(Autocomplete::zip('0203'), 4, ['id', 'text']);
-        $this->contentAssertions(Autocomplete::zip('02038'), 1, ['id', 'text']);
+        $this->contentAssertions(Autocomplete::zip($query), $expectedResults, $contentKeys);
     }
 }


### PR DESCRIPTION
- add use of dataProviders for providing arrays of test params for city & zip tests

fixes #12 